### PR TITLE
Add getters to the mutable store

### DIFF
--- a/src/state/store.js
+++ b/src/state/store.js
@@ -66,11 +66,16 @@ export default (incomingStore = {}, schemas = {}, options = {}) => {
   };
 
   const setAll = mountPointsAndPayloads => {
+    _setAll(mountPointsAndPayloads);
+    update();
+  };
+
+  const _setAll = mountPointsAndPayloads => {
     Object.entries(mountPointsAndPayloads).forEach(([mountPoint, payload]) =>
       _set(mountPoint, payload)
     );
-    update();
   };
+
   const store = {};
   setAll(incomingStore);
 
@@ -92,7 +97,10 @@ export default (incomingStore = {}, schemas = {}, options = {}) => {
     );
 
   const mutableStore = {
-    set: _set
+    get,
+    set: _set,
+    getAll,
+    setAll: _setAll
   };
 
   const withMutations = fn => {

--- a/src/state/store.test.js
+++ b/src/state/store.test.js
@@ -65,8 +65,9 @@ describe("Store", () => {
     store.subscribe(fn2);
     store.withMutations(s => {
       s.set("a", 1);
-      s.set("b", 2);
-      s.set("c", 3);
+      s.setAll({ b: 2, c: 3 });
+      expect(s.get("a")).to.equal(1);
+      expect(s.getAll(["b", "c"])).to.eql({ b: 2, c: 3 });
     });
     expect(store.get("a")).to.equal(1);
     expect(store.get("b")).to.equal(2);


### PR DESCRIPTION
This enables actions to operate on the mutable store to provide grouping for operations as atomic operations externally.