### PR TITLE
replaced ajv json schema with lightweight version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "react": ">=15"
   },
   "dependencies": {
-    "ajv": "6.0.1",
-    "query-string": "5.0.1"
+    "query-string": "5.0.1",
+    "tiny-json-validator": "2.0.0"
   },
   "devDependencies": {
     "babel-core": "6.26.0",

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -29,9 +29,7 @@ export default (incomingStore = {}, schemas = {}, options = {}) => {
   const state$ = makeSubject();
   const updateIntercepts = [];
 
-  const schemasMap = new Map(
-    Object.entries(schemas).map(([mountPoint, schema]) => [mountPoint, schema])
-  );
+  const schemasMap = new Map(Object.entries(schemas));
 
   const validate = (mountPoint, payload) => {
     let valid = true;

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,4 +1,4 @@
-import Ajv from "ajv";
+import jsonValidator from "tiny-json-validator";
 
 const makeSubject = () => {
   const observers = new Map();
@@ -29,23 +29,20 @@ export default (incomingStore = {}, schemas = {}, options = {}) => {
   const state$ = makeSubject();
   const updateIntercepts = [];
 
-  const ajv = new Ajv();
-  const ajvSchemas = new Map(
-    Object.entries(schemas).map(([mountPoint, schema]) => [
-      mountPoint,
-      ajv.compile(schema)
-    ])
+  const schemasMap = new Map(
+    Object.entries(schemas).map(([mountPoint, schema]) => [mountPoint, schema])
   );
 
   const validate = (mountPoint, payload) => {
     let valid = true;
-    if (ajvSchemas.has(mountPoint)) {
-      const validate = ajvSchemas.get(mountPoint);
-      valid = validate(payload);
+    if (schemasMap.has(mountPoint)) {
+      const schema = schemasMap.get(mountPoint);
+      const validatorResponse = jsonValidator(schema, payload);
+      valid = validatorResponse.isValid;
       if (throwOnValidation && !valid)
         throw new Error(
           JSON.stringify(
-            { payload, mountPoint, error: validate.errors },
+            { payload, mountPoint, error: validatorResponse.errors },
             null,
             "\t"
           )

--- a/src/state/store.test.js
+++ b/src/state/store.test.js
@@ -2,6 +2,7 @@
 import { expect } from "chai";
 import { createStore } from "../main";
 import { createSelector } from "reselect";
+import validator from "tiny-json-validator";
 
 describe("Store", () => {
   it("can be initialised with an initial state", () => {
@@ -134,7 +135,7 @@ describe("Store", () => {
       {
         a: 10
       },
-      { a: { type: "number" } }
+      { a: { type: "integer" } }
     );
 
     expect(store.get("a")).to.equal(10);
@@ -149,7 +150,7 @@ describe("Store", () => {
       {
         a: 10
       },
-      { a: { type: "number" } },
+      { a: { type: "integer" } },
       { throwOnValidation: true }
     );
 
@@ -161,7 +162,7 @@ describe("Store", () => {
       {
         a: 10
       },
-      { a: { type: "number" } },
+      { a: { type: "integer" } },
       { throwOnMissingSchemas: true }
     );
     store.set("a", 30);

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,14 +71,6 @@ ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
 
-ajv@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.0.1.tgz#2898580a9f3def5f9c85dfead7a2223ef13cf3da"
-  dependencies:
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -2666,10 +2658,6 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
-
-fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -6115,6 +6103,10 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-json-validator@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tiny-json-validator/-/tiny-json-validator-2.0.0.tgz#7699b6b5dc3c26412fbae4551ad2dc4864da0283"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
I've replaced the full blown json schema validator with this very basic one: https://github.com/nitely/tiny-json-validator

It only supports these type: [integer, string, array, object]
Should be sufficient for our purposes and it shaves off nearly 200K from the build