### PR TITLE
stripped out schema validator dependency

### DIFF
--- a/demo/features/counter/actions-selectors.js
+++ b/demo/features/counter/actions-selectors.js
@@ -1,12 +1,20 @@
+import Ajv from "ajv";
+const ajv = new Ajv();
+
 export const mountPoint = "counter";
 
-export const schema = {
+const schema = {
   type: "object",
   properties: {
     value: {
       type: "integer"
     }
   }
+};
+
+export const validator = data => {
+  const validated = ajv.validate(schema, data);
+  return { valid: validated, errors: ajv.errors };
 };
 
 export const initialState = {

--- a/demo/features/counter2/actions-selectors.js
+++ b/demo/features/counter2/actions-selectors.js
@@ -1,12 +1,20 @@
+import Ajv from "ajv";
+const ajv = new Ajv();
+
 export const mountPoint = "counter2";
 
-export const schema = {
+const schema = {
   type: "object",
   properties: {
     value: {
       type: "integer"
     }
   }
+};
+
+export const validator = data => {
+  const validated = ajv.validate(schema, data);
+  return { valid: validated, errors: ajv.errors };
 };
 
 export const initialState = {

--- a/demo/index.js
+++ b/demo/index.js
@@ -4,12 +4,12 @@ import App from "./app";
 import {
   initialState as counterInitialState,
   mountPoint as counterMountPoint,
-  schema as counterSchema
+  validator as counterValidator
 } from "./features/counter/actions-selectors";
 import {
   initialState as counterInitialState2,
   mountPoint as counterMountPoint2,
-  schema as counterSchema2
+  validator as counterValidator2
 } from "./features/counter2/actions-selectors";
 import { createStore, Container, enableHistory } from "../src/main";
 import createDocsExample from "./docs-example";
@@ -17,8 +17,8 @@ import createDocsExample from "./docs-example";
 const store = createStore(
   Object.assign(counterInitialState, counterInitialState2),
   {
-    [counterMountPoint]: counterSchema,
-    [counterMountPoint2]: counterSchema2
+    [counterMountPoint]: counterValidator,
+    [counterMountPoint2]: counterValidator2
   }
 );
 enableHistory(store, [counterMountPoint], [counterMountPoint2]);

--- a/package.json
+++ b/package.json
@@ -52,10 +52,9 @@
     "prop-types": ">=15",
     "react": ">=15"
   },
-  "dependencies": {
-    "tiny-json-validator": "2.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "ajv": "6.1.1",
     "babel-core": "6.26.0",
     "babel-eslint": "8.0.0",
     "babel-jest": "21.0.2",

--- a/src/state/store.js
+++ b/src/state/store.js
@@ -1,5 +1,3 @@
-import jsonValidator from "tiny-json-validator";
-
 const makeSubject = () => {
   const observers = new Map();
   let idPtr = 0;
@@ -21,7 +19,7 @@ const defaultOptions = {
   throwOnMissingSchemas: false
 };
 
-export default (incomingStore = {}, schemas = {}, options = {}) => {
+export default (incomingStore = {}, validators = {}, options = {}) => {
   const { throwOnValidation, throwOnMissingSchemas } = {
     ...defaultOptions,
     ...options
@@ -29,14 +27,14 @@ export default (incomingStore = {}, schemas = {}, options = {}) => {
   const state$ = makeSubject();
   const updateIntercepts = [];
 
-  const schemasMap = new Map(Object.entries(schemas));
+  const validatorsMap = new Map(Object.entries(validators));
 
   const validate = (mountPoint, payload) => {
     let valid = true;
-    if (schemasMap.has(mountPoint)) {
-      const schema = schemasMap.get(mountPoint);
-      const validatorResponse = jsonValidator(schema, payload);
-      valid = validatorResponse.isValid;
+    if (validatorsMap.has(mountPoint)) {
+      const validator = validatorsMap.get(mountPoint);
+      const validatorResponse = validator(payload);
+      valid = validatorResponse.valid;
       if (throwOnValidation && !valid)
         throw new Error(
           JSON.stringify(

--- a/src/state/store.test.js
+++ b/src/state/store.test.js
@@ -2,7 +2,8 @@
 import { expect } from "chai";
 import { createStore } from "../main";
 import { createSelector } from "reselect";
-import validator from "tiny-json-validator";
+import Ajv from "ajv";
+const ajv = new Ajv();
 
 describe("Store", () => {
   it("can be initialised with an initial state", () => {
@@ -131,11 +132,19 @@ describe("Store", () => {
   });
 
   it("does not update store if json schema validation fails", () => {
+    const schema = { type: "integer" };
+    const validators = {
+      a: data => {
+        const validated = ajv.validate(schema, data);
+        return { valid: validated, errors: ajv.errors };
+      }
+    };
+
     const store = createStore(
       {
         a: 10
       },
-      { a: { type: "integer" } }
+      validators
     );
 
     expect(store.get("a")).to.equal(10);
@@ -146,11 +155,19 @@ describe("Store", () => {
   });
 
   it("throws a validation error if throwOnValidation flag is set", () => {
+    const schema = { type: "integer" };
+    const validators = {
+      a: data => {
+        const validated = ajv.validate(schema, data);
+        return { valid: validated, errors: ajv.errors };
+      }
+    };
+
     const store = createStore(
       {
         a: 10
       },
-      { a: { type: "integer" } },
+      validators,
       { throwOnValidation: true }
     );
 
@@ -158,11 +175,19 @@ describe("Store", () => {
   });
 
   it("throws an error if throwOnMissingSchemas flag is set to a schema is missing ", () => {
+    const schema = { type: "integer" };
+    const validators = {
+      a: data => {
+        const validated = ajv.validate(schema, data);
+        return { valid: validated, errors: ajv.errors };
+      }
+    };
+
     const store = createStore(
       {
         a: 10
       },
-      { a: { type: "integer" } },
+      validators,
       { throwOnMissingSchemas: true }
     );
     store.set("a", 30);

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,6 +71,14 @@ ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.0.tgz#a296e17f7bfae7c1ce4f7e0de53d29cb32162df0"
 
+ajv@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.1.1.tgz#978d597fbc2b7d0e5a5c3ddeb149a682f2abfa0e"
+  dependencies:
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -2654,6 +2662,10 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -6087,10 +6099,6 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
     setimmediate "^1.0.4"
-
-tiny-json-validator@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tiny-json-validator/-/tiny-json-validator-2.0.0.tgz#7699b6b5dc3c26412fbae4551ad2dc4864da0283"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Its now entirely up to the user of the reduxless library to provide a validator function for each/any mountpoints. It could be a custom function or a json schema validator: reduxless doesn't care anymore.