### PR TITLE
Bump to v1.0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduxless",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "",
   "main": "dist/reduxless.cjs.js",
   "module": "dist/reduxless.esm.js",


### PR DESCRIPTION
Stripped out schema validation. Its up to the user of this library to provide their own validation mechanism.