### PR TITLE
Bump to v1.0.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduxless",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "",
   "main": "dist/reduxless.js",
   "engines": {


### PR DESCRIPTION
Removed use of Object.entries which can cause issues in Chrome v64